### PR TITLE
Fix: test if acpi exists to avoid error message

### DIFF
--- a/prompt.bash
+++ b/prompt.bash
@@ -160,7 +160,11 @@ git_branch_color()
 battery()
 {
     command -v acpi >/dev/null 2>&1 || { echo -n ""; return; }
-    bat=`acpi --battery | sed "s/^Battery .*, \([0-9]*\)%.*$/\1/"`
+    bat=`acpi --battery 2>/dev/null | sed "s/^Battery .*, \([0-9]*\)%.*$/\1/"`
+    if [ "${bat}x" == "x" ] ; then
+	echo -n ""
+	return
+    fi
     if [ ${bat} -lt 90 ] ; then
         echo -n " ${bat}%"
     else

--- a/prompt.bash
+++ b/prompt.bash
@@ -159,6 +159,7 @@ git_branch_color()
 # Get the battery status in percent
 battery()
 {
+    command -v acpi >/dev/null 2>&1 || { echo -n ""; return; }
     bat=`acpi --battery | sed "s/^Battery .*, \([0-9]*\)%.*$/\1/"`
     if [ ${bat} -lt 90 ] ; then
         echo -n " ${bat}%"


### PR DESCRIPTION
Hi

A patch to avoid error message when acpi is not installed.

Regards,
